### PR TITLE
Change password handling, switched login to API.

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Easily integrate [IBM Application Security on Cloud](https://appscan.ibmcloud.co
 
    ![](https://github.com/AppSecDev/asoc-bamboo-plugin/blob/master/images/install2.png)
 
-3. Enter your IBM Application Security on Cloud account user name and password in the Bamboo shared credentials page.
+3. Enter your IBM Application Security on Cloud account [API Key ID and Secret Key] (https://www.ibm.com/support/knowledgecenter/SSYJJF_1.0.0/ApplicationSecurityonCloud/appseccloud_generate_api_key_cm.html) in the Bamboo shared credentials page.
 
 # Adding the SAST Scan Task to your Build Plan
 

--- a/src/main/java/com/ibm/appscan/bamboo/plugin/impl/SASTScanTask.java
+++ b/src/main/java/com/ibm/appscan/bamboo/plugin/impl/SASTScanTask.java
@@ -21,7 +21,6 @@ import com.atlassian.bamboo.plan.artifact.ArtifactDefinitionContext;
 import com.atlassian.bamboo.plan.artifact.ArtifactDefinitionContextImpl;
 import com.atlassian.bamboo.plan.artifact.ArtifactPublishingResult;
 import com.atlassian.bamboo.process.ProcessService;
-import com.atlassian.bamboo.security.EncryptionService;
 import com.atlassian.bamboo.task.TaskContext;
 import com.atlassian.bamboo.task.TaskException;
 import com.atlassian.bamboo.task.TaskResult;
@@ -43,15 +42,13 @@ public class SASTScanTask implements TaskType, ISASTConstants, IArtifactPublishe
 	
 	private ArtifactManager artifactManager;
 	private CredentialsManager credentialsManager;
-	private EncryptionService encryptionService;
 	private CapabilityContext capabilityContext;
 	
 	public SASTScanTask(
 			@ComponentImport I18nBeanFactory i18nBeanFactory, 
 			@ComponentImport ProcessService processService, 
 			@ComponentImport ArtifactManager artifactManager, 
-			@ComponentImport CredentialsManager credentialsManager, 
-			@ComponentImport EncryptionService encryptionService, 
+			@ComponentImport CredentialsManager credentialsManager,  
 			@ComponentImport CapabilityContext capabilityContext) {
 		
 		logger = new LogHelper(i18nBeanFactory.getI18nBean());
@@ -59,7 +56,6 @@ public class SASTScanTask implements TaskType, ISASTConstants, IArtifactPublishe
 		
 		this.artifactManager = artifactManager;
 		this.credentialsManager = credentialsManager;
-		this.encryptionService = encryptionService;
 		this.capabilityContext = capabilityContext;
 	}
 	
@@ -90,7 +86,7 @@ public class SASTScanTask implements TaskType, ISASTConstants, IArtifactPublishe
 		String username = credentials.getConfiguration().get("username"); //$NON-NLS-1$
 		scanner.setUsername(username);
 		
-		String password = encryptionService.decrypt(credentials.getConfiguration().get("password")); //$NON-NLS-1$
+		String password = credentials.getConfiguration().get("password"); //$NON-NLS-1$
 		scanner.setPassword(password);
 		
 		// this ensures password is masked in build log

--- a/src/main/java/com/ibm/appscan/bamboo/plugin/impl/SASTScanner.java
+++ b/src/main/java/com/ibm/appscan/bamboo/plugin/impl/SASTScanner.java
@@ -141,7 +141,7 @@ public class SASTScanner implements ISASTConstants, IJSONConstants {
 				taskContext, 
 				createExternalProcessBuilder(
 						taskContext,
-						"scx_login",		//$NON-NLS-1$
+						"api_login",		//$NON-NLS-1$
 						"-u", username,		//$NON-NLS-1$
 						"-P", password, 	//$NON-NLS-1$
 						"-persist"));		//$NON-NLS-1$


### PR DESCRIPTION
Change the password handling. The EncryptionService was deprecated and it's not compatible with latest version. Now password is pulled straight from the credentials manager.
https://github.com/AppSecDev/asoc-bamboo-plugin/compare/master...coadaflorin:bamboo-6.0.3?expand=1#diff-9c88c35f32d707f7f2eadb4d583dbd83

The log-in is now done using the API/Secret key password instead of ASoC username/password. 
https://github.com/AppSecDev/asoc-bamboo-plugin/compare/master...coadaflorin:bamboo-6.0.3?expand=1#diff-e5fd65d2c7b8adedb171fe3688a8c4b6